### PR TITLE
Rework quickbuy

### DIFF
--- a/content/panorama/scripts/arena_util.js
+++ b/content/panorama/scripts/arena_util.js
@@ -160,6 +160,59 @@ function dynamicSort(property) {
 	};
 }
 
+function ShallowCopy(origin) {
+	var rv = [];
+	for (var key in origin) {
+		rv[key] = origin[key];
+	}
+	return rv;
+}
+
+function isEmpty(array) {
+   var empty = true;
+
+   for(var key in array) {
+      empty = false;
+      break;
+   }
+
+   return empty;
+}
+
+function isEqual(A, B) {
+	for (var key in A) {
+		if(B[key] !== A[key]) {
+			return false;
+		}
+	}
+	for (var key in B) {
+		if(B[key] !== A[key]) {
+			return false;
+		}
+	}
+	return true;
+}
+
+function GetItemsInFlaggedUnits (nEntityIndex, nflaggedEntities, bStash) {
+	var itemCounter = [];
+	var endPoint = 8;
+	if (bStash)
+		endPoint = 14;
+	for (var key in nflaggedEntities) {
+		var entity = nflaggedEntities[key]
+		if (entity !== null) {
+			for (var i = endPoint; i >= 0; i--) {
+				var item = Entities.GetItemInSlot(entity, i);
+				if (Items.GetPurchaser(item) === nEntityIndex) {
+					var itemName = Abilities.GetAbilityName(item);
+					itemCounter[itemName] = itemCounter[itemName] === undefined ? 1 : itemCounter[itemName] + 1;
+				}
+			}
+		}
+	}
+	return itemCounter;
+}
+
 function GetItemCountInInventory(nEntityIndex, itemName, bStash) {
 	var counter = 0;
 	var endPoint = 8;

--- a/game/scripts/vscripts/filters.lua
+++ b/game/scripts/vscripts/filters.lua
@@ -3,6 +3,7 @@ Events:Register("activate", function ()
 	GameRules:GetGameModeEntity():SetDamageFilter(Dynamic_Wrap(GameMode, 'DamageFilter'), GameRules)
 	GameRules:GetGameModeEntity():SetModifyGoldFilter(Dynamic_Wrap(GameMode, 'ModifyGoldFilter'), GameRules)
 	GameRules:GetGameModeEntity():SetModifyExperienceFilter(Dynamic_Wrap(GameMode, 'ModifyExperienceFilter'), GameRules)
+	GameRules:GetGameModeEntity():SetItemAddedToInventoryFilter(Dynamic_Wrap(GameMode, 'ItemAddedToInventoryFilter'), GameRules)
 end)
 
 function GameMode:ExecuteOrderFilter(filterTable)
@@ -271,5 +272,24 @@ function GameMode:ModifyExperienceFilter(filterTable)
 	if Duel.IsFirstDuel and Duel:IsDuelOngoing() then
 		filterTable.experience = filterTable.experience * 0.1
 	end
+	return true
+end
+
+function GameMode:ItemAddedToInventoryFilter(filterTable)
+	local item = EntIndexToHScript(filterTable.item_entindex_const)
+	--Send info to panorama shops
+	if not item.isNotNew then
+		item.isNotNew = true
+		local abilityName = item:GetAbilityName()
+		local owner = item:GetPurchaser()
+		if owner then
+			local ownerIndex = owner:GetEntityIndex()
+			CustomGameEventManager:Send_ServerToAllClients("arena_new_item", {item = filterTable.item_entindex_const, itemName = abilityName, owner = ownerIndex})
+		end
+	end
+	if item.suggested_slot then
+		filterTable.suggested_slot = item.suggested_slot
+	end
+	
 	return true
 end


### PR DESCRIPTION
- [X] Saves inventory data every update. Only updates inventory data (and quickbuy) on inventory update events. Searches the array instead of querying units when finding quickbuy required items.
- [X] Quickbuy now only ends when the **last uncomplete set** has been completed by **purchasing** an item that completes the set and having it **remain in the inventory (not dropping)**, or by **purchasing or assembling** the item
- [X] Quickbuy now works properly with stackable items