### PR TITLE
Golden arrow now requires 0 cost recipe

### DIFF
--- a/game/scripts/npc/npc_items_custom.txt
+++ b/game/scripts/npc/npc_items_custom.txt
@@ -8866,7 +8866,7 @@
 		"ItemResult"					"item_golden_arrow"
 		"ItemRequirements"
 		{
-			"01"						"item_blades_of_attack;item_boots"
+			"01"						"item_blades_of_attack;item_boots;item_recipe_golden_arrow"
 		}
 	}
 


### PR DESCRIPTION
so phase boots are easier to build