### PR TITLE
Custom shop hotkeys now override player default shop hotkeys

### DIFF
--- a/content/panorama/layout/custom_game/arena_setup.xml
+++ b/content/panorama/layout/custom_game/arena_setup.xml
@@ -33,9 +33,9 @@
 		</snippet>
 	</snippets>
 	<Panel hittest="false" class="TeamSelect">
-		<DOTAHotkey id="PurchaseSticky" keybind="PurchaseSticky" hittest="false"/>
-		<DOTAHotkey id="PurchaseQuickbuy" keybind="PurchaseQuickbuy" hittest="false"/>
-		<DOTAHotkey id="ShopToggle" keybind="ShopToggle" hittest="false"/>
+		<DOTAHotkey id="PurchaseSticky" keybind="PurchaseSticky" hittest="false" class="hidden"/>
+		<DOTAHotkey id="PurchaseQuickbuy" keybind="PurchaseQuickbuy" hittest="false" class="hidden"/>
+		<DOTAHotkey id="ShopToggle" keybind="ShopToggle" hittest="false" class="hidden"/>
 		<Panel id="team-select__open">
 			<Panel id="TeamList" />
 			<Panel hittest="false" id="SettingsColumn" >

--- a/content/panorama/layout/custom_game/arena_setup.xml
+++ b/content/panorama/layout/custom_game/arena_setup.xml
@@ -7,6 +7,7 @@
 	<scripts>
 		<include src="file://{resources}/scripts/arena_util.js" />
 		<include src="file://{resources}/scripts/arena_setup.js" />
+		<include src="file://{resources}/scripts/hotkey_tracker.js" />
 	</scripts>
 	<snippets>
 		<snippet name="Team">
@@ -32,6 +33,9 @@
 		</snippet>
 	</snippets>
 	<Panel hittest="false" class="TeamSelect">
+		<DOTAHotkey id="PurchaseSticky" keybind="PurchaseSticky" hittest="false"/>
+		<DOTAHotkey id="PurchaseQuickbuy" keybind="PurchaseQuickbuy" hittest="false"/>
+		<DOTAHotkey id="ShopToggle" keybind="ShopToggle" hittest="false"/>
 		<Panel id="team-select__open">
 			<Panel id="TeamList" />
 			<Panel hittest="false" id="SettingsColumn" >

--- a/content/panorama/layout/custom_game/arena_setup.xml
+++ b/content/panorama/layout/custom_game/arena_setup.xml
@@ -33,9 +33,6 @@
 		</snippet>
 	</snippets>
 	<Panel hittest="false" class="TeamSelect">
-		<DOTAHotkey id="PurchaseSticky" keybind="PurchaseSticky" hittest="false" class="hidden"/>
-		<DOTAHotkey id="PurchaseQuickbuy" keybind="PurchaseQuickbuy" hittest="false" class="hidden"/>
-		<DOTAHotkey id="ShopToggle" keybind="ShopToggle" hittest="false" class="hidden"/>
 		<Panel id="team-select__open">
 			<Panel id="TeamList" />
 			<Panel hittest="false" id="SettingsColumn" >

--- a/content/panorama/scripts/arena_util.js
+++ b/content/panorama/scripts/arena_util.js
@@ -4,6 +4,7 @@
 var PlayerTables = GameUI.CustomUIConfig().PlayerTables;
 var _ = GameUI.CustomUIConfig()._;
 var Options = GameUI.CustomUIConfig().Options;
+var RegisterKeyBind = GameUI.CustomUIConfig().RegisterKeyBind;
 
 var console = {
 	log: function() {

--- a/content/panorama/scripts/custom_ui_manifest.js
+++ b/content/panorama/scripts/custom_ui_manifest.js
@@ -35,7 +35,6 @@ GameUI.CustomUIConfig().team_names[DOTATeam_t.DOTA_TEAM_CUSTOM_6] = $.Localize("
 GameUI.CustomUIConfig().team_names[DOTATeam_t.DOTA_TEAM_CUSTOM_7] = $.Localize("#DOTA_Custom7");
 GameUI.CustomUIConfig().team_names[DOTATeam_t.DOTA_TEAM_CUSTOM_8] = $.Localize("#DOTA_Custom8");*/
 
-Game.Events = {};
 Game.MouseEvents = {
 	OnLeftPressed: []
 };

--- a/content/panorama/scripts/custom_ui_manifest.js
+++ b/content/panorama/scripts/custom_ui_manifest.js
@@ -35,16 +35,6 @@ GameUI.CustomUIConfig().team_names[DOTATeam_t.DOTA_TEAM_CUSTOM_6] = $.Localize("
 GameUI.CustomUIConfig().team_names[DOTATeam_t.DOTA_TEAM_CUSTOM_7] = $.Localize("#DOTA_Custom7");
 GameUI.CustomUIConfig().team_names[DOTATeam_t.DOTA_TEAM_CUSTOM_8] = $.Localize("#DOTA_Custom8");*/
 
-function RegisterKeybind(command) {
-	Game.Events[command] = [];
-	Game.AddCommand('+' + command, function() {
-		for (var key in Game.Events[command]) {
-			Game.Events[command][key]();
-		}
-	}, '', 0);
-	Game.AddCommand('-' + command, function() {}, '', 0);
-}
-
 Game.Events = {};
 Game.MouseEvents = {
 	OnLeftPressed: []
@@ -72,9 +62,6 @@ GameUI.SetMouseCallback(function(eventName, arg) {
 	};
 	return result;
 });
-RegisterKeybind('F4Pressed');
-RegisterKeybind('F5Pressed');
-RegisterKeybind('F8Pressed');
 
 GameUI.CustomUIConfig().custom_entity_values = GameUI.CustomUIConfig().custom_entity_values || {};
 DynamicSubscribeNTListener('custom_entity_values', function(tableName, key, value) {

--- a/content/panorama/scripts/hotkey_tracker.js
+++ b/content/panorama/scripts/hotkey_tracker.js
@@ -2,7 +2,6 @@ Game.Events = {};
 
 function GetKeybind(key) {
 	var keyElement = $("#" + key);
-	keyElement.visibility = "collapse";
 	return keyElement.GetChild(0).text;
 }
 
@@ -19,9 +18,8 @@ function RegisterKeybind(command) {
 function GenerateKeybind(defaultName, sign, command, defaultKey) {
 	RegisterKeybind(command);
 	var key = GetKeybind(defaultName)
-	if (key === '') {
+	if (key === '')
 		key = defaultKey
-	}
 	Game.CreateCustomKeyBind(key, sign + command)
 }
 

--- a/content/panorama/scripts/hotkey_tracker.js
+++ b/content/panorama/scripts/hotkey_tracker.js
@@ -1,27 +1,34 @@
 Game.Events = {};
+var contextPanel = $.GetContextPanel();
 
-function GetKeybind(key) {
-	var keyElement = $("#" + key);
+function GetCommandName(name) {
+	return 'arena_hotkey_' + _.snakeCase(name);
+}
+
+function GetKeyBind(name) {
+	contextPanel.BCreateChildren('<DOTAHotkey keybind="' + name + '" />');
+	var keyElement = contextPanel.GetChild(contextPanel.GetChildCount() - 1);
+	keyElement.DeleteAsync(0);
 	return keyElement.GetChild(0).text;
 }
 
-function RegisterKeybind(command) {
-	Game.Events[command] = [];
-	Game.AddCommand(command, function() {
-		for (var key in Game.Events[command]) {
-			Game.Events[command][key]();
+function RegisterKeyBindHandler(name) {
+	Game.Events[name] = {};
+	Game.AddCommand(GetCommandName(name), function() {
+		for (var key in Game.Events[name]) {
+			Game.Events[name][key]();
 		}
 	}, '', 0);
 }
 
-function GenerateKeybind(defaultName, command) {
-	RegisterKeybind(command);
-	var key = GetKeybind(defaultName)
-	if (key !== '') Game.CreateCustomKeyBind(key, command)
-}
+function RegisterKeyBind(name, callback) {
+	if (Game.Events[name] == null) {
+		RegisterKeyBindHandler(name);
+		var key = GetKeyBind(name)
+		if (key !== '') Game.CreateCustomKeyBind(key, GetCommandName(name));
+	}
 
-(function() {
-	GenerateKeybind("ShopToggle", "F4Pressed")
-	GenerateKeybind("PurchaseQuickbuy", "F5Pressed")
-	GenerateKeybind("PurchaseSticky", "F8Pressed")
-})();
+	Game.Events[name][callback.name] = callback;
+};
+
+GameUI.CustomUIConfig().RegisterKeyBind = RegisterKeyBind;

--- a/content/panorama/scripts/hotkey_tracker.js
+++ b/content/panorama/scripts/hotkey_tracker.js
@@ -15,16 +15,15 @@ function RegisterKeybind(command) {
 	Game.AddCommand('-' + command, function() {}, '', 0);
 }
 
-function GenerateKeybind(defaultName, sign, command, defaultKey) {
+function GenerateKeybind(defaultName, sign, command) {
 	RegisterKeybind(command);
 	var key = GetKeybind(defaultName)
-	if (key === '')
-		key = defaultKey
-	Game.CreateCustomKeyBind(key, sign + command)
+	if (key !== '')
+		Game.CreateCustomKeyBind(key, sign + command)
 }
 
 (function() {
-	GenerateKeybind("ShopToggle", "+", "F4Pressed", "F4")
-	GenerateKeybind("PurchaseQuickbuy", "+", "F5Pressed", "F5")
-	GenerateKeybind("PurchaseSticky", "+", "F8Pressed", "F8")
+	GenerateKeybind("ShopToggle", "+", "F4Pressed")
+	GenerateKeybind("PurchaseQuickbuy", "+", "F5Pressed")
+	GenerateKeybind("PurchaseSticky", "+", "F8Pressed")
 })();

--- a/content/panorama/scripts/hotkey_tracker.js
+++ b/content/panorama/scripts/hotkey_tracker.js
@@ -7,23 +7,21 @@ function GetKeybind(key) {
 
 function RegisterKeybind(command) {
 	Game.Events[command] = [];
-	Game.AddCommand('+' + command, function() {
+	Game.AddCommand(command, function() {
 		for (var key in Game.Events[command]) {
 			Game.Events[command][key]();
 		}
 	}, '', 0);
-	Game.AddCommand('-' + command, function() {}, '', 0);
 }
 
-function GenerateKeybind(defaultName, sign, command) {
+function GenerateKeybind(defaultName, command) {
 	RegisterKeybind(command);
 	var key = GetKeybind(defaultName)
-	if (key !== '')
-		Game.CreateCustomKeyBind(key, sign + command)
+	if (key !== '') Game.CreateCustomKeyBind(key, command)
 }
 
 (function() {
-	GenerateKeybind("ShopToggle", "+", "F4Pressed")
-	GenerateKeybind("PurchaseQuickbuy", "+", "F5Pressed")
-	GenerateKeybind("PurchaseSticky", "+", "F8Pressed")
+	GenerateKeybind("ShopToggle", "F4Pressed")
+	GenerateKeybind("PurchaseQuickbuy", "F5Pressed")
+	GenerateKeybind("PurchaseSticky", "F8Pressed")
 })();

--- a/content/panorama/scripts/hotkey_tracker.js
+++ b/content/panorama/scripts/hotkey_tracker.js
@@ -1,8 +1,8 @@
 Game.Events = {};
 
 function GetKeybind(key) {
-	var keyElement = $('#' + key)
-	keyElement.visibility = "collapse"
+	var keyElement = $("#" + key);
+	keyElement.visibility = "collapse";
 	return keyElement.GetChild(0).text;
 }
 
@@ -16,13 +16,17 @@ function RegisterKeybind(command) {
 	Game.AddCommand('-' + command, function() {}, '', 0);
 }
 
-function GenerateKeybind(defaultName, sign, command) {
+function GenerateKeybind(defaultName, sign, command, defaultKey) {
 	RegisterKeybind(command);
-	Game.CreateCustomKeyBind(GetKeybind(defaultName), sign + command)
+	var key = GetKeybind(defaultName)
+	if (key === '') {
+		key = defaultKey
+	}
+	Game.CreateCustomKeyBind(key, sign + command)
 }
 
 (function() {
-	GenerateKeybind("ShopToggle", "+", "F4Pressed")
-	GenerateKeybind("PurchaseQuickbuy", "+", "F5Pressed")
-	GenerateKeybind("PurchaseSticky", "+", "F8Pressed")
+	GenerateKeybind("ShopToggle", "+", "F4Pressed", "F4")
+	GenerateKeybind("PurchaseQuickbuy", "+", "F5Pressed", "F5")
+	GenerateKeybind("PurchaseSticky", "+", "F8Pressed", "F8")
 })();

--- a/content/panorama/scripts/hotkey_tracker.js
+++ b/content/panorama/scripts/hotkey_tracker.js
@@ -1,8 +1,8 @@
-'use strict';
+Game.Events = {};
 
 function GetKeybind(key) {
-	var keyElement = $.GetContextPanel().FindChildTraverse(key)
-	keyElement.visible = false;
+	var keyElement = $('#' + key)
+	keyElement.visibility = "collapse"
 	return keyElement.GetChild(0).text;
 }
 

--- a/content/panorama/scripts/hotkey_tracker.js
+++ b/content/panorama/scripts/hotkey_tracker.js
@@ -1,0 +1,28 @@
+'use strict';
+
+function GetKeybind(key) {
+	var keyElement = $.GetContextPanel().FindChildTraverse(key)
+	keyElement.visible = false;
+	return keyElement.GetChild(0).text;
+}
+
+function RegisterKeybind(command) {
+	Game.Events[command] = [];
+	Game.AddCommand('+' + command, function() {
+		for (var key in Game.Events[command]) {
+			Game.Events[command][key]();
+		}
+	}, '', 0);
+	Game.AddCommand('-' + command, function() {}, '', 0);
+}
+
+function GenerateKeybind(defaultName, sign, command) {
+	RegisterKeybind(command);
+	Game.CreateCustomKeyBind(GetKeybind(defaultName), sign + command)
+}
+
+(function() {
+	GenerateKeybind("ShopToggle", "+", "F4Pressed")
+	GenerateKeybind("PurchaseQuickbuy", "+", "F5Pressed")
+	GenerateKeybind("PurchaseSticky", "+", "F8Pressed")
+})();

--- a/content/panorama/scripts/panorama_shop.js
+++ b/content/panorama/scripts/panorama_shop.js
@@ -476,9 +476,9 @@ function SetItemStock(item, ItemStock) {
 	GameUI.SetDefaultUIEnabled(DotaDefaultUIElement_t.DOTA_DEFAULT_UI_INVENTORY_SHOP, true);
 	GameUI.SetDefaultUIEnabled(DotaDefaultUIElement_t.DOTA_DEFAULT_UI_SHOP_SUGGESTEDITEMS, true);
 	GameUI.SetDefaultUIEnabled(DotaDefaultUIElement_t.DOTA_DEFAULT_UI_INVENTORY_QUICKBUY, true);
-	Game.Events.F4Pressed.push(OpenCloseShop);
+	RegisterKeyBind('ShopToggle', OpenCloseShop);
 	GameEvents.Subscribe('panorama_shop_open_close', OpenCloseShop);
-	Game.Events.F5Pressed.push(function() {
+	RegisterKeyBind('PurchaseQuickbuy', function() {
 		if (QuickBuyTarget != null) {
 			var bought = false;
 			var QuickBuyPanelItems = $('#QuickBuyPanelItems');
@@ -504,7 +504,7 @@ function SetItemStock(item, ItemStock) {
 			}
 		}
 	});
-	Game.Events.F8Pressed.push(function() {
+	RegisterKeyBind('PurchaseSticky', function() {
 		SendItemBuyOrder($('#QuickBuyStickyButtonPanel').GetChild(0).itemName);
 	});
 	Game.MouseEvents.OnLeftPressed.push(function(ClickBehaviors, eventName, arg) {

--- a/game/addoninfo.txt
+++ b/game/addoninfo.txt
@@ -45,26 +45,4 @@
 		"MaxPlayers"		"16"
 		"TeamCount"			"4"
 	}
-
-	"Default_Keys"
-	{
-		"01"
-		{
-			"Key" "F4"
-			"Command" "+F4Pressed"
-			"Name" "Toggle Shop"
-		}
-		"02"
-		{
-			"Key" "F5"
-			"Command" "+F5Pressed"
-			"Name" "Quickbuy"
-		}
-		"03"
-		{
-			"Key" "F8"
-			"Command" "+F8Pressed"
-			"Name" "Buy sticky item"
-		}
-	}
 }


### PR DESCRIPTION
Works by ripping off the values of DOTAHotkey elements, which display whatever hotkey you want.