### PR TITLE
Unit query no longer display talent tree

### DIFF
--- a/content/panorama/scripts/custom_hud.js
+++ b/content/panorama/scripts/custom_hud.js
@@ -125,6 +125,7 @@ function HookPanoramaPanels() {
 	FindDotaHudElement('HUDSkinMinimap').visible = false;
 	FindDotaHudElement('combat_events').visible = false;
 	FindDotaHudElement('ChatEmoticonButton').visible = false;
+	FindDotaHudElement('StatBranchIcon').visible = false;
 	FindDotaHudElement('StatBranchDrawer').visible = false;
 	FindDotaHudElement('topbar').visible = false;
 	FindDotaHudElement('DeliverItemsButton').style.horizontalAlign = 'right';


### PR DESCRIPTION
Only affects people with Unit query overrides hero console disabled