### PR TITLE
Custom illusions now duplicate Morphling in morph properly

### DIFF
--- a/game/scripts/vscripts/modules/illusions/illusions.lua
+++ b/game/scripts/vscripts/modules/illusions/illusions.lua
@@ -101,12 +101,18 @@ function Illusions:create(info)
 	local isOwned = info.isOwned
 	if isOwned == nil then isOwned = true end
 
+	local source = unit
+	local replicate_modifier = unit:FindModifierByName("modifier_morphling_replicate")
+	if replicate_modifier then
+		source = replicate_modifier:GetCaster()
+	end
+
 	local illusion = CreateUnitByName(
-		unit:GetUnitName(),
+		source:GetUnitName(),
 		origin,
 		true,
 		isOwned and unit or nil,
-		isOwned and unit:GetPlayerOwner() or nil,
+		isOwned and source:GetPlayerOwner() or nil,
 		team
 	)
 	if isOwned then illusion:SetControllableByPlayer(unit:GetPlayerID(), true) end

--- a/game/scripts/vscripts/modules/illusions/illusions.lua
+++ b/game/scripts/vscripts/modules/illusions/illusions.lua
@@ -102,9 +102,9 @@ function Illusions:create(info)
 	if isOwned == nil then isOwned = true end
 
 	local source = unit
-	local replicate_modifier = unit:FindModifierByName("modifier_morphling_replicate")
-	if replicate_modifier then
-		source = replicate_modifier:GetCaster()
+	local replicateModifier = unit:FindModifierByName("modifier_morphling_replicate")
+	if replicateModifier then
+		source = replicateModifier:GetCaster()
 	end
 
 	local illusion = CreateUnitByName(


### PR DESCRIPTION
Properly as in consistent with base Dota2 behavior

Not that Valve did it properly, just that this makes it consistent with Dota 2 behavior

That is

- [X] Creates illusion of morph source with morphling's level/stuff
- [X] When inspected, will be exactly like source
- [X] Does NOT retain Morphling's stats, because normal Dota and Valve
- [X] Yes, the name will be the name of whatever Morphling duplicates