### PR TITLE
(balance) Cursed Zeld can no longer copy illusions

### DIFF
--- a/game/scripts/npc/abilities/bosses/cursed_zeld.txt
+++ b/game/scripts/npc/abilities/bosses/cursed_zeld.txt
@@ -73,7 +73,7 @@
 		"AbilityCastRange"				"1000"
 		"AbilityUnitTargetType"			"DOTA_UNIT_TARGET_HERO"
 		"AbilityUnitTargetTeam"			"DOTA_UNIT_TARGET_TEAM_ENEMY"
-		"AbilityUnitTargetFlags"		"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitTargetFlags"		"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_NOT_ILLUSIONS"
 
 		"AbilitySpecial"
 		{


### PR DESCRIPTION
So Phantom Lancer can no longer crash the game using Cursed Zeld