### PR TITLE
Reduce timer checks per tick to 2

### DIFF
--- a/game/scripts/vscripts/libraries/binheap.lua
+++ b/game/scripts/vscripts/libraries/binheap.lua
@@ -1,7 +1,7 @@
 -- Binary Heap implementation copy-pasted from https://gist.github.com/starwing/1757443a1bd295653c39
--- BinaryHeap[1] always points to the element of greatest priority.
+-- BinaryHeap[1] always points to the element with the lowest "key" variable
 -- API
--- BinaryHeap(key) - Creates a new BinaryHeap with key
+-- BinaryHeap(key) - Creates a new BinaryHeap with key. The key is the name of the integer variable used to sort objects.
 -- BinaryHeap:Insert - Inserts an object into BinaryHeap
 -- BinaryHeap:Remove - Removes an object from BinaryHeap
 

--- a/game/scripts/vscripts/libraries/binheap.lua
+++ b/game/scripts/vscripts/libraries/binheap.lua
@@ -1,0 +1,60 @@
+-- Binary Heap implementation copy-pasted from https://gist.github.com/starwing/1757443a1bd295653c39
+-- BinaryHeap[1] always points to the element of greatest priority.
+-- API
+-- BinaryHeap(key) - Creates a new BinaryHeap with key
+-- BinaryHeap:Insert - Inserts an object into BinaryHeap
+-- BinaryHeap:Remove - Removes an object from BinaryHeap
+
+BinaryHeap = BinaryHeap or {}
+BinaryHeap.__index = BinaryHeap
+
+function BinaryHeap:Insert(item)
+	local index = #self + 1
+	local key = self.key
+	item.index = index
+	self[index] = item
+	while index > 1 do
+		local parent = math.floor(index/2)
+		if self[parent][key] <= item[key] then
+			break
+		end
+		self[index], self[parent] = self[parent], self[index]
+		self[index].index = index
+		self[parent].index = parent
+		index = parent
+	end
+	return item
+end
+
+function BinaryHeap:Remove(item)
+	local index = item.index
+	if self[index] ~= item then return end
+	local key = self.key
+	local heap_size = #self
+	if index == heap_size then
+		self[heap_size] = nil
+		return
+	end
+	self[index] = self[heap_size]
+	self[index].index = index
+	self[heap_size] = nil
+	while true do
+		local left = index*2
+		local right = left + 1
+		if not self[left] then break end
+		local newindex = right
+		if self[index][key] >= self[left][key] then
+			if not self[right] or self[left][key] < self[right][key] then
+				newindex = left
+			end
+		elseif not self[right] or self[index][key] <= self[right][key] then
+			break
+		end
+		self[index], self[newindex] = self[newindex], self[index]
+		self[index].index = index
+		self[newindex].index = newindex
+		index = newindex
+	end
+end
+
+setmetatable(BinaryHeap, {__call = function(self, key) return setmetatable({key=key}, self) end})

--- a/game/scripts/vscripts/libraries/timers.lua
+++ b/game/scripts/vscripts/libraries/timers.lua
@@ -222,7 +222,6 @@ function Timers:NextTick(callback)
 end
 
 function Timers:RemoveTimer(name)
-
 	local timerHeap = self.gameTimeHeap
 	if name.useGameTime ~= nil and name.useGameTime == false then
 		timerHeap = self.realTimeHeap

--- a/game/scripts/vscripts/libraries/timers.lua
+++ b/game/scripts/vscripts/libraries/timers.lua
@@ -216,7 +216,6 @@ function Timers:CreateTimer(name, args, context)
 		return
 	end
 
-
 	local now = GameRules:GetGameTime()
 	local timers = self.timers
 	local timerHeap = timers.gameTime

--- a/game/scripts/vscripts/libraries/timers.lua
+++ b/game/scripts/vscripts/libraries/timers.lua
@@ -205,6 +205,8 @@ function Timers:CreateTimer(arg1, arg2, context)
 
 	if arg2.endTime == nil then
 		arg2.endTime = now
+	else
+		arg2.endTime = now + arg2.endTime
 	end
 
 	arg2.context = context

--- a/game/scripts/vscripts/libraries/timers.lua
+++ b/game/scripts/vscripts/libraries/timers.lua
@@ -181,39 +181,40 @@ function Timers:HandleEventError(name, event, err)
 end
 
 function Timers:CreateTimer(arg1, arg2, context)
+	local timer
 	if type(arg1) == "function" then
 		if arg2 ~= nil then
 			context = arg2
 		end
-		arg2 = {callback = arg1}
+		timer = {callback = arg1}
 	elseif type(arg1) == "table" then
-		arg2 = arg1
+		timer = arg1
 	elseif type(arg1) == "number" then
-		arg2 = {endTime = arg1, callback = arg2}
+		timer = {endTime = arg1, callback = arg2}
 	end
-	if not arg2.callback then
-		print("Invalid timer created: "..arg1)
+	if not timer.callback then
+		print("Invalid timer created")
 		return
 	end
 
 	local now = GameRules:GetGameTime()
 	local timerHeap = self.gameTimeHeap
-	if arg2.useGameTime ~= nil and arg2.useGameTime == false then
+	if timer.useGameTime ~= nil and timer.useGameTime == false then
 		now = Time()
 		timerHeap = self.realTimeHeap
 	end
 
-	if arg2.endTime == nil then
-		arg2.endTime = now
+	if timer.endTime == nil then
+		timer.endTime = now
 	else
-		arg2.endTime = now + arg2.endTime
+		timer.endTime = now + timer.endTime
 	end
 
-	arg2.context = context
+	timer.context = context
 
-	timerHeap:Insert(arg2)
+	timerHeap:Insert(timer)
 
-	return arg2
+	return timer
 end
 
 function Timers:NextTick(callback)

--- a/game/scripts/vscripts/libraries/timers.lua
+++ b/game/scripts/vscripts/libraries/timers.lua
@@ -224,7 +224,7 @@ function Timers:RemoveTimer(name)
 
 	local timerHeap = self.gameTimeHeap
 	if name.useGameTime ~= nil and name.useGameTime == false then
-		timerHeap = timers.realTimeHeap
+		timerHeap = self.realTimeHeap
 	end
 	
 	timerHeap:Remove(name)


### PR DESCRIPTION
Credits: https://gist.github.com/starwing/1757443a1bd295653c39 for binary tree implimentation

1 check for realtime 1 check for gametime

Not all things are tested, but picking, arena, boss respawn, weather, and meta potion seems to be working fine

Binary heap extracted to another file in case someone wants to code something that only need to know the top value but does not necessarily want everything in order

Basic theory for binary heap: each node has up to 2 children, both children of which must be of lower priority (in this case, higher time remaining) than the parent. Children can be accessed by index * 2 and index * 2 + 1, because the number of nodes in the lower level is always 2x the number of nodes in the higher level (level with 4 nodes has 8 total children) and because of recursive math things the nodes in a level is always 1 more than all nodes in all higher levels. Similarly, parent node can be accessed by floor(index / 2).
![heap](https://user-images.githubusercontent.com/32054822/49961931-d623c300-ff4e-11e8-8049-8faabd7576f5.png)

When you add node it basically append to end and swap with parent node (node at position index/2) until parent node is of higher priority than child node. When you remove node it basically places the node at the end of the array in the empty pos and swaps with children until both children have lower priority
