### PR TITLE
Revert armor calc

### DIFF
--- a/game/scripts/vscripts/filters.lua
+++ b/game/scripts/vscripts/filters.lua
@@ -131,11 +131,6 @@ function GameMode:DamageFilter(filterTable)
 		attacker = EntIndexToHScript(filterTable.entindex_attacker_const)
 	end
 	local victim = EntIndexToHScript(filterTable.entindex_victim_const)
-	
-	local armor = victim.current_armor
-	if armor and armor > 0 and damagetype_const == 1 then
-		filterTable.damage = filterTable.damage * (1 - ( 0.05 * armor ) / ( 1 + 0.05 * armor ))
-	end
 
 	if IsValidEntity(attacker) then
 		if IsValidEntity(inflictor) and inflictor.GetAbilityName then

--- a/game/scripts/vscripts/filters.lua
+++ b/game/scripts/vscripts/filters.lua
@@ -131,6 +131,11 @@ function GameMode:DamageFilter(filterTable)
 		attacker = EntIndexToHScript(filterTable.entindex_attacker_const)
 	end
 	local victim = EntIndexToHScript(filterTable.entindex_victim_const)
+	
+	local armor = victim.current_armor
+	if armor and armor > 0 and damagetype_const == 1 then
+		filterTable.damage = filterTable.damage * (1 - ( 0.05 * armor ) / ( 1 + 0.05 * armor ))
+	end
 
 	if IsValidEntity(attacker) then
 		if IsValidEntity(inflictor) and inflictor.GetAbilityName then

--- a/game/scripts/vscripts/modifiers/modifier_arena_hero.lua
+++ b/game/scripts/vscripts/modifiers/modifier_arena_hero.lua
@@ -15,17 +15,17 @@ function modifier_arena_hero:DeclareFunctions()
 		MODIFIER_EVENT_ON_RESPAWN,
 		MODIFIER_PROPERTY_MAGICAL_RESISTANCE_DIRECT_MODIFICATION,
 		MODIFIER_PROPERTY_PREATTACK_CRITICALSTRIKE,
-		MODIFIER_PROPERTY_IGNORE_PHYSICAL_ARMOR,
+		MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS,
 	}
 end
 
-function modifier_arena_hero:GetModifierIgnorePhysicalArmor()
+function modifier_arena_hero:GetModifierPhysicalArmorBonus()
 	if not self.calculatingArmor then
 		self.calculatingArmor = true
 		local parent = self:GetParent()
 		parent.current_armor = parent:GetPhysicalArmorValue()
 		self.calculatingArmor = nil
-		return 1
+		return -parent.current_armor
 	end
 	return 0
 end
@@ -39,7 +39,7 @@ function modifier_arena_hero:GetModifierMagicalResistanceDirectModification()
 end
 
 if IsClient() then
-	function modifier_arena_hero:GetModifierIgnorePhysicalArmor() return 0 end
+	function modifier_arena_hero:GetModifierPhysicalArmorBonus() return 0 end
 end
 
 if IsServer() then

--- a/game/scripts/vscripts/modifiers/modifier_arena_hero.lua
+++ b/game/scripts/vscripts/modifiers/modifier_arena_hero.lua
@@ -23,9 +23,12 @@ function modifier_arena_hero:GetModifierPhysicalArmorBonus()
 	if not self.calculatingArmor then
 		self.calculatingArmor = true
 		local parent = self:GetParent()
-		parent.current_armor = parent:GetPhysicalArmorValue()
+		local armor = parent:GetPhysicalArmorValue()
+		parent.current_armor = armor
+		local resistance = ( 0.05 * armor ) / ( 1 + 0.05 * armor ) --old resistance
+		local correctedArmor = ( 0.9 * resistance ) / ( 0.052 - 0.048 * resistance ) --transforms into new armor required for old resistance
 		self.calculatingArmor = nil
-		return -parent.current_armor
+		return -parent.current_armor + correctedArmor
 	end
 	return 0
 end

--- a/game/scripts/vscripts/modifiers/modifier_arena_hero.lua
+++ b/game/scripts/vscripts/modifiers/modifier_arena_hero.lua
@@ -15,17 +15,17 @@ function modifier_arena_hero:DeclareFunctions()
 		MODIFIER_EVENT_ON_RESPAWN,
 		MODIFIER_PROPERTY_MAGICAL_RESISTANCE_DIRECT_MODIFICATION,
 		MODIFIER_PROPERTY_PREATTACK_CRITICALSTRIKE,
-		MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS,
+		MODIFIER_PROPERTY_IGNORE_PHYSICAL_ARMOR,
 	}
 end
 
-function modifier_arena_hero:GetModifierPhysicalArmorBonus()
+function modifier_arena_hero:GetModifierIgnorePhysicalArmor()
 	if not self.calculatingArmor then
 		self.calculatingArmor = true
 		local parent = self:GetParent()
 		parent.current_armor = parent:GetPhysicalArmorValue()
 		self.calculatingArmor = nil
-		return -parent.current_armor
+		return 1
 	end
 	return 0
 end
@@ -39,7 +39,7 @@ function modifier_arena_hero:GetModifierMagicalResistanceDirectModification()
 end
 
 if IsClient() then
-	function modifier_arena_hero:GetModifierPhysicalArmorBonus() return 0 end --visuals
+	function modifier_arena_hero:GetModifierIgnorePhysicalArmor() return 0 end
 end
 
 if IsServer() then

--- a/game/scripts/vscripts/modifiers/modifier_arena_hero.lua
+++ b/game/scripts/vscripts/modifiers/modifier_arena_hero.lua
@@ -15,7 +15,19 @@ function modifier_arena_hero:DeclareFunctions()
 		MODIFIER_EVENT_ON_RESPAWN,
 		MODIFIER_PROPERTY_MAGICAL_RESISTANCE_DIRECT_MODIFICATION,
 		MODIFIER_PROPERTY_PREATTACK_CRITICALSTRIKE,
+		MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS,
 	}
+end
+
+function modifier_arena_hero:GetModifierPhysicalArmorBonus()
+	if not self.calculatingArmor then
+		self.calculatingArmor = true
+		local parent = self:GetParent()
+		parent.current_armor = parent:GetPhysicalArmorValue()
+		self.calculatingArmor = nil
+		return -parent.current_armor
+	end
+	return 0
 end
 
 function modifier_arena_hero:GetModifierAbilityLayout()
@@ -24,6 +36,10 @@ end
 
 function modifier_arena_hero:GetModifierMagicalResistanceDirectModification()
 	return self.resistanceDifference or self:GetSharedKey("resistanceDifference") or 0
+end
+
+if IsClient() then
+	function modifier_arena_hero:GetModifierPhysicalArmorBonus() return 0 end --visuals
 end
 
 if IsServer() then


### PR DESCRIPTION
This reverts armor back to what it was for heroes but the resistance panel is not updated

works by making server think there is no armor but client still think there is armor

edit: damage numbers now display correct values