### PR TITLE
(balance) AS cap removed

### DIFF
--- a/game/scripts/vscripts/modifiers/modifier_arena_hero.lua
+++ b/game/scripts/vscripts/modifiers/modifier_arena_hero.lua
@@ -16,7 +16,6 @@ function modifier_arena_hero:DeclareFunctions()
 		MODIFIER_PROPERTY_MAGICAL_RESISTANCE_DIRECT_MODIFICATION,
 		MODIFIER_PROPERTY_PREATTACK_CRITICALSTRIKE,
 		MODIFIER_PROPERTY_BASE_ATTACK_TIME_CONSTANT,
-		MODIFIER_EVENT_ON_ATTACK,
 	}
 end
 
@@ -29,18 +28,6 @@ function modifier_arena_hero:GetModifierMagicalResistanceDirectModification()
 end
 
 if IsServer() then
-
-	function modifier_arena_hero:OnAttack(keys)
-		local parent = self:GetParent()
-		if parent ~= keys.attacker or keys.no_attack_cooldown == true or not self.ExtraAttacksPerAttack then return end
-		self.MaxASExtraAttacks = (self.MaxASExtraAttacks or 0) + self.ExtraAttacksPerAttack
-		while self.MaxASExtraAttacks > 1 do
-			parent:PerformAttack(keys.target, true, true, true, false, true, false, false)
-			self.MaxASExtraAttacks = self.MaxASExtraAttacks - 1
-		end
-		return
-	end
-
 	function modifier_arena_hero:GetModifierBaseAttackTimeConstant()
 		if self.calculatingBAT then return -1 end
 		self.calculatingBAT = true
@@ -56,7 +43,6 @@ if IsServer() then
 		local NewBAT = BAT * MaxAS * postMaxASReductionFactor / (AS + (postMaxASReductionFactor - 1) * MaxAS)
 		local MaxBAT = 0.01 * MaxAS
 		if NewBAT < MaxBAT then
-			self.ExtraAttacksPerAttack = MaxBAT / NewBAT - 1
 			NewBAT = MaxBAT
 		end
 		self.calculatingBAT = false

--- a/game/scripts/vscripts/modifiers/modifier_arena_hero.lua
+++ b/game/scripts/vscripts/modifiers/modifier_arena_hero.lua
@@ -15,6 +15,7 @@ function modifier_arena_hero:DeclareFunctions()
 		MODIFIER_EVENT_ON_RESPAWN,
 		MODIFIER_PROPERTY_MAGICAL_RESISTANCE_DIRECT_MODIFICATION,
 		MODIFIER_PROPERTY_PREATTACK_CRITICALSTRIKE,
+		MODIFIER_PROPERTY_BASE_ATTACK_TIME_CONSTANT,
 	}
 end
 
@@ -27,6 +28,26 @@ function modifier_arena_hero:GetModifierMagicalResistanceDirectModification()
 end
 
 if IsServer() then
+
+	function modifier_arena_hero:GetModifierBaseAttackTimeConstant()
+		if self.calculatingBAT then return -1 end
+		self.calculatingBAT = true
+		local parent = self:GetParent()
+		local BAT = parent:GetBaseAttackTime()
+		local AS = parent:GetIncreasedAttackSpeed()
+		local MaxAS = GameRules:GetGameModeEntity():GetMaximumAttackSpeed()
+		if AS < MaxAS then
+			AS = MaxAS
+		end
+		local NewBAT = BAT * MaxAS / AS
+		local MaxBAT = 0.01 * MaxAS
+		if NewBAT < MaxBAT then
+			NewBAT = MaxBAT
+		end
+		self.calculatingBAT = false
+		return NewBAT
+	end
+
 	function modifier_arena_hero:GetModifierPreAttack_CriticalStrike()
 		if RollPercentage(15) then
 			return self.agilityCriticalDamage

--- a/game/scripts/vscripts/modifiers/modifier_arena_hero.lua
+++ b/game/scripts/vscripts/modifiers/modifier_arena_hero.lua
@@ -32,14 +32,12 @@ if IsServer() then
 
 	function modifier_arena_hero:OnAttack(keys)
 		local parent = self:GetParent()
-		if parent ~= keys.attacker or not self.ExtraAttacksPerAttack or self.PerformingExtraAttacks then return end
+		if parent ~= keys.attacker or keys.no_attack_cooldown == true or not self.ExtraAttacksPerAttack then return end
 		self.MaxASExtraAttacks = (self.MaxASExtraAttacks or 0) + self.ExtraAttacksPerAttack
-		self.PerformingExtraAttacks = true
 		while self.MaxASExtraAttacks > 1 do
 			parent:PerformAttack(keys.target, true, true, true, false, true, false, false)
 			self.MaxASExtraAttacks = self.MaxASExtraAttacks - 1
 		end
-		self.PerformingExtraAttacks = false
 		return
 	end
 

--- a/game/scripts/vscripts/modifiers/modifier_arena_hero.lua
+++ b/game/scripts/vscripts/modifiers/modifier_arena_hero.lua
@@ -52,7 +52,7 @@ if IsServer() then
 			self.calculatingBAT = false
 			return -1
 		end
-		AS = (AS - MaxAS) / 4 + MaxAS
+		AS = (AS - MaxAS) / 10 + MaxAS
 		local NewBAT = BAT * MaxAS / AS
 		local MaxBAT = 0.01 * MaxAS
 		if NewBAT < MaxBAT then

--- a/game/scripts/vscripts/modifiers/modifier_arena_hero.lua
+++ b/game/scripts/vscripts/modifiers/modifier_arena_hero.lua
@@ -52,8 +52,8 @@ if IsServer() then
 			self.calculatingBAT = false
 			return -1
 		end
-		AS = (AS - MaxAS) / 10 + MaxAS
-		local NewBAT = BAT * MaxAS / AS
+		local postMaxASReductionFactor = 10
+		local NewBAT = BAT * MaxAS * postMaxASReductionFactor / (AS + (postMaxASReductionFactor - 1) * MaxAS)
 		local MaxBAT = 0.01 * MaxAS
 		if NewBAT < MaxBAT then
 			self.ExtraAttacksPerAttack = MaxBAT / NewBAT - 1

--- a/game/scripts/vscripts/modifiers/modifier_arena_hero.lua
+++ b/game/scripts/vscripts/modifiers/modifier_arena_hero.lua
@@ -52,6 +52,7 @@ if IsServer() then
 			self.calculatingBAT = false
 			return -1
 		end
+		AS = (AS - MaxAS) / 4 + MaxAS
 		local NewBAT = BAT * MaxAS / AS
 		local MaxBAT = 0.01 * MaxAS
 		if NewBAT < MaxBAT then


### PR DESCRIPTION
Base Attack Time still affects rate of lowering attack time via AS

new max AS (0.01 attack time) can be reached at around 20K AGI on a normal hero but around 60K on Saitama

would be a great buff to AGI heroes, esp. those with crits who don't scale with new agi crit (PA)

unfortunately, the UI don't update properly, but internally it works fine

EDIT: removed AS cap entirely. Having AS beyond even this AS cap will make your attacks spawn multiple attacks based on your extra AS